### PR TITLE
feat(originals-to-assets): add USE_ASSET_TYPE_SUBFOLDERS option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,7 @@ RETAIN_TCM_OVERLAID_IMAGES=0                 # keep images that have the TCM ove
 USE_ASSET_NAMING=1                           # should grab-all-posters name images to match Kometa's Asset Directory requirements?
 USE_ASSET_FOLDERS=1                          # should those Kometa-Asset-Directory names use asset folders?
 USE_ASSET_SUBFOLDERS=0                       # create asset folders in subfolders ["Collections", "Other", or [0-9, A-Z]] ]
+USE_ASSET_TYPE_SUBFOLDERS=0                  # should those Kometa-Asset-Directory names use asset type subfolders (movie, show)?
 ASSETS_BY_LIBRARIES=1                        # should those Kometa-Asset-Directory images be sorted into library folders?
 ASSET_DIR=assets                             # top-level directory for those Kometa-Asset-Directory images
                                              # if asset-directory naming is on, the next three are ignored                                            

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 **/*.log
 **/*.pickle
 **/*.sqlite
+**/.python-version
 
 Kometa/metadata-items
 

--- a/Kometa/.env.example
+++ b/Kometa/.env.example
@@ -18,6 +18,7 @@ KOMETA_CONFIG_DIR=/opt/kometa/config # Path to Kometa config directory
 
 # ORIGINAL TO ASSETS
 USE_ASSET_FOLDERS=1                              # should those Kometa-Asset-Directory names use asset folders?
+USE_ASSET_TYPE_SUBFOLDERS=0                      # should those Kometa-Asset-Directory names use asset type subfolders (movie, show)?
 ASSET_DIR=assets                                 # top-level directory for those Kometa-Asset-Directory images
 KOMETA_CONFIG_DIR=/kometa/is/here
 

--- a/Kometa/README.md
+++ b/Kometa/README.md
@@ -269,17 +269,37 @@ If you don't have overlays on any episodes, this script will not put any episode
 ```
 # ORIGINAL TO ASSETS
 USE_ASSET_FOLDERS=1                          # should the asset directory use asset folders?
+USE_ASSET_TYPE_SUBFOLDERS=1                  # optionally, should the asset directory use asset type subfolders? (e.g. 'movie', 'show')
 ASSET_DIR=assets                             # top-level directory for those assets
 ```
-The asset file system will be rooted at the directory in the `ASSET_DIR` setting, and `USE_ASSET_FOLDERS` controls whether the images are stored as:
+The asset file system will be rooted at the directory in the `ASSET_DIR` setting, while `USE_ASSET_FOLDERS` and `USE_ASSET_TYPE_SUBFOLDERS` controls whether the images are stored as:
 
 `USE_ASSET_FOLDERS=0`
 ```
-Media-Scripts/Plex/assets/All That Jazz (1979) {imdb-tt0078754} {tmdb-16858}.jpg
+# movie|show
+Media-Scripts/Plex/assets/<ASSET_NAME>.jpg
+# season
+Media-Scripts/Plex/assets/<ASSET_NAME>_Season##.jpg
+# episode
+Media-Scripts/Plex/assets/<ASSET_NAME>_S##E##.jpg
 ```
 or `USE_ASSET_FOLDERS=1`
 ```
-Media-Scripts/Plex/assets/All That Jazz (1979) {imdb-tt0078754} {tmdb-16858}/poster.jpg
+# movie|show
+Media-Scripts/Plex/assets/<ASSET_NAME>/poster.jpg
+# season
+Media-Scripts/Plex/assets/<ASSET_NAME>/Season##.jpg
+# episode
+Media-Scripts/Plex/assets/<ASSET_NAME>/S##E##.jpg
+```
+with `USE_ASSET_TYPE_SUBFOLDERS=1`
+```
+# movie|show
+Media-Scripts/Plex/assets/<movie|show>/...
+# season
+Media-Scripts/Plex/assets/show/...
+# episode
+Media-Scripts/Plex/assets/show/...
 ```
 
 example output:

--- a/Kometa/originals-to-assets.py
+++ b/Kometa/originals-to-assets.py
@@ -22,8 +22,9 @@ SCRIPT_NAME = Path(__file__).stem
 # 0.0.4 more chatty logging and bail if the original isn't found
 # 0.0.5 Actually fix TV libraries
 # 0.0.6 use parent directory name rather than stem
+# 0.0.7 add USE_ASSET_TYPE_SUBFOLDERS option
 
-VERSION = "0.0.6"
+VERSION = "0.0.7"
 
 env_file_path = Path(".env")
 
@@ -87,6 +88,7 @@ if ASSET_DIR is None:
 ASSET_PATH = Path(ASSET_DIR)
 
 USE_ASSET_FOLDERS = booler(os.getenv("USE_ASSET_FOLDERS"))
+USE_ASSET_TYPE_SUBFOLDERS = booler(os.getenv("USE_ASSET_TYPE_SUBFOLDERS"))
 
 if ASSET_DIR is None:
     ASSET_DIR = "assets"
@@ -191,27 +193,47 @@ def target_asset(item):
         superchat(f"Episode asset name: {asset_name}", "info", "a")
 
     if USE_ASSET_FOLDERS:
-        # Movie/Show poster      <path_to_assets>/ASSET_NAME/poster.ext
-        target_file = Path(ASSET_PATH, asset_name, "poster.jpg")
-        # Season poster          <path_to_assets>/ASSET_NAME/Season##.ext
+        if USE_ASSET_TYPE_SUBFOLDERS:
+            # If using type subfolders, then assets go in a subfolder for their type (movie or show):
+            #   Movie/Show poster:     -> <ASSET_PATH>/<movie|show>/<ASSET_NAME>
+            #   Season/Episode poster: -> <ASSET_PATH>/show/<ASSET_NAME>
+            type_subfolder = "movie" if item.TYPE == "movie" else "show"
+            base_path = Path(ASSET_PATH, type_subfolder, asset_name)
+        else:
+            # Flat asset structure: all assets go directly in an ASSET_PATH/<ASSET_NAME> folder
+            base_path = Path(ASSET_PATH, asset_name)
+
         if item.TYPE == "season":
-            target_file = Path(
-                ASSET_PATH, asset_name, f"Season{str(item_season).zfill(2)}.jpg"
-            )
-        # Episode poster         <path_to_assets>/ASSET_NAME/S##E##.ext
-        if item.TYPE == "episode":
-            target_file = Path(ASSET_PATH, asset_name, f"{item_se_str}.jpg")
+            # Season poster:  <base_path>/Season##.jpg
+            target_file = base_path / f"Season{str(item_season).zfill(2)}.jpg"
+        elif item.TYPE == "episode":
+            # Episode poster: <base_path>/S##E##.jpg
+            target_file = base_path / f"{item_se_str}.jpg"
+        else:
+            # Movie/Show poster: <base_path>/poster.jpg
+            target_file = base_path / "poster.jpg"
     else:
-        # Movie/Show poster      <path_to_assets>/ASSET_NAME.ext
-        target_file = Path(ASSET_PATH, f"{asset_name}.jpg")
-        # Season poster          <path_to_assets>/ASSET_NAME_Season##.ext
+        if USE_ASSET_TYPE_SUBFOLDERS:
+            # If using type subfolders, then assets go in a subfolder for their type (movie or show):
+            #   Movie/Show poster:     -> <ASSET_PATH>/<movie|show>
+            #   Season/Episode poster: -> <ASSET_PATH>/show
+            type_subfolder = "movie" if item.TYPE == "movie" else "show"
+            base_path = Path(ASSET_PATH, type_subfolder)
+        else:
+            # Flat asset structure: all assets go directly in the ASSET_PATH
+            base_path = ASSET_PATH
+
         if item.TYPE == "season":
-            target_file = Path(
-                ASSET_PATH, f"{asset_name}_Season{str(item_season).zfill(2)}.jpg"
+            target_file = (
+                base_path
+                / f"{asset_name}_Season{str(item_season).zfill(2)}.jpg"  # <ASSET_NAME>_Season##.jpg
             )
-        # Episode poster         <path_to_assets>/ASSET_NAME_S##E##.ext
-        if item.TYPE == "episode":
-            target_file = Path(ASSET_PATH, f"{asset_name}_{item_se_str}.jpg")
+        elif item.TYPE == "episode":
+            target_file = (
+                base_path / f"{asset_name}_{item_se_str}.jpg"  # <ASSET_NAME>_S##E##.jpg
+            )
+        else:
+            target_file = base_path / f"{asset_name}.jpg"  # <ASSET_NAME>.jpg
 
     superchat(f"Target file: {target_file}", "info", "a")
 


### PR DESCRIPTION
### Summary

Adds a new `USE_ASSET_TYPE_SUBFOLDERS` option to `Kometa/originals-to-assets.py` that places assets into `movie/` or `show/` subfolders within the asset directory. This is useful for Kometa setups that separate movie and TV assets at the folder level.

- Introduces the `USE_ASSET_TYPE_SUBFOLDERS` env var, documented and defaulted to `0` in both `.env.example` files
- Updates `README.md` with the full matrix of path structures across all combinations of `USE_ASSET_FOLDERS` and `USE_ASSET_TYPE_SUBFOLDERS`, covering all media types (movie, show, season, episode)
- Bumps version to `0.0.7`

**Path structure with `USE_ASSET_TYPE_SUBFOLDERS=1`**
| `USE_ASSET_FOLDERS` | Type | Path |
|---|---|---|
| `1` | movie | `<ASSET_PATH>/movie/<ASSET_NAME>/poster.jpg` |
| | show | `<ASSET_PATH>/show/<ASSET_NAME>/poster.jpg` |
| | season | `<ASSET_PATH>/show/<ASSET_NAME>/Season##.jpg` |
| | episode | `<ASSET_PATH>/show/<ASSET_NAME>/S##E##.jpg` |
| `0` | movie | `<ASSET_PATH>/movie/<ASSET_NAME>.jpg` |
| | show | `<ASSET_PATH>/show/<ASSET_NAME>.jpg` |
| | season | `<ASSET_PATH>/show/<ASSET_NAME>_Season##.jpg` |
| | episode | `<ASSET_PATH>/show/<ASSET_NAME>_S##E##.jpg` |
